### PR TITLE
Fix typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Use [black](https://github.com/ambv/black) and [prettier](https://prettier.io/)
 to make sure the code follows the style.
 
 Or use the `pre-commit` settings implemented in this repository
-(see deicated section below).
+(see dedicated section below).
 
 ## Pre-commit
 


### PR DESCRIPTION
## Summary
- fix a misspelled word in CONTRIBUTING.md

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68698295d90c8329971584d4ac669bec