### PR TITLE
Fix setup error by removing efficiency sensor

### DIFF
--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -51,7 +51,6 @@ DEFAULT_DATA = {
         "temperature": 0,
         "power_limit": 0,
         "miner_consumption": 0,
-        "efficiency": 0.0,
     },
     "board_sensors": {},
     "fan_sensors": {},
@@ -195,7 +194,6 @@ class MinerCoordinator(DataUpdateCoordinator):
                 "active_preset_name": miner_data.config.mining_mode.active_preset.name,
                 "temperature": miner_data.temperature_avg,
                 "miner_consumption": miner_data.wattage,
-                "efficiency": miner_data.efficiency_fract,
             },
             "board_sensors": {
                 board.slot: {

--- a/custom_components/miner/sensor.py
+++ b/custom_components/miner/sensor.py
@@ -19,7 +19,6 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .const import JOULES_PER_TERA_HASH
 from .const import TERA_HASH_PER_SECOND
 from .coordinator import MinerCoordinator
 
@@ -86,12 +85,6 @@ ENTITY_DESCRIPTION_KEY_MAP: dict[str, SensorEntityDescription] = {
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
-        entity_category=EntityCategory.DIAGNOSTIC,
-    ),
-    "efficiency": SensorEntityDescription(
-        key="Efficiency",
-        native_unit_of_measurement=JOULES_PER_TERA_HASH,
-        state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     "fan_speed": SensorEntityDescription(


### PR DESCRIPTION
## Summary
- drop efficiency data from miner coordinator
- remove efficiency sensor definition

## Testing
- `pre-commit run --files custom_components/miner/coordinator.py custom_components/miner/sensor.py`

------
https://chatgpt.com/codex/tasks/task_e_686988f143288329ac932b3d0684072b