### PR TITLE
Add manual curtail switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Works great in coordination with [ESPHome](https://www.home-assistant.io/integra
 | `curtail_wakeup`  | Resume mining after curtailment      |
 | `curtail_sleep`   | Stop mining due to curtailment       |
 
+## Manual curtail switch
+
+A `Curtail` switch is also created for each configured miner. Turning this
+switch **off** triggers the `curtail_sleep` service to stop mining, while
+turning it **on** calls `curtail_wakeup` to resume mining.
+
 ## Temperature curtail automation
 
 After installing the integration, a built-in automation monitors the


### PR DESCRIPTION
## Summary
- add a new `MinerCurtailSwitch` entity for manual stop/start
- expose the switch during setup
- document the new switch in README

## Testing
- `scripts/lint`

------
https://chatgpt.com/codex/tasks/task_e_68698e1690b08329b465b5f2ee997059