### PR TITLE
Adjust ambient threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,13 @@ Works great in coordination with [ESPHome](https://www.home-assistant.io/integra
 
 After installing the integration, a built-in automation monitors the
 `sensor.econet_hpwh_ambient_temperature` entity every five minutes. If the
-temperature drops below **64°F**, mining resumes using the `curtail_wakeup`
+temperature drops below **65°F**, mining resumes using the `curtail_wakeup`
 service. When the temperature rises above **70°F**, the `curtail_sleep`
 service stops mining. This automation is disabled on weekdays between **2 PM**
 
 and **9 PM** Eastern Time. During those hours the integration checks if your
 miner is active and will issue the `curtail_sleep` command to ensure it
 remains stopped.
-
 
 No additional configuration is required. Simply ensure the temperature sensor
 exists in Home Assistant with the entity ID listed above.

--- a/custom_components/miner/__init__.py
+++ b/custom_components/miner/__init__.py
@@ -67,7 +67,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             ambient = float(state.state)
         except ValueError:
             return
-        if ambient < 64:
+        if ambient < 65:
             await miner.resume_mining()
         elif ambient > 70:
             await miner.stop_mining()


### PR DESCRIPTION
## Summary
- increase ambient temperature threshold for resuming mining from 64°F to 65°F
- update documentation to reflect the new threshold

## Testing
- `pre-commit run --files custom_components/miner/__init__.py README.md`

------
https://chatgpt.com/codex/tasks/task_e_6869d8b9c8648329a0f4ccba90e919d5